### PR TITLE
Windows環境でも動作するようデータベースURLを修正（dunceクレートを使用）

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.words": [
+        "canonicalize",
         "gihyo",
         "Tauri"
     ]

--- a/kanban-03/src-tauri/Cargo.lock
+++ b/kanban-03/src-tauri/Cargo.lock
@@ -662,6 +662,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bd4b30a6560bbd9b4620f4de34c3f14f60848e58a9b7216801afcb4c7b31c3c"
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,6 +1473,7 @@ name = "kanban"
 version = "0.3.0"
 dependencies = [
  "directories",
+ "dunce",
  "futures",
  "serde",
  "serde_json",

--- a/kanban-03/src-tauri/Cargo.toml
+++ b/kanban-03/src-tauri/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.0.0", features = ["api-all"] }
 directories = "4.0.1"
+dunce = "1.0.3"
 futures = "0.3.23"
 sqlx = { version = "0.6.1", features = ["runtime-tokio-rustls", "sqlite", "migrate"] }
 tokio = { version = "1.20.1", features = ["full"] }

--- a/kanban-03/src-tauri/src/main.rs
+++ b/kanban-03/src-tauri/src/main.rs
@@ -132,7 +132,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // データベースURLを作成する
-    let database_dir_str = std::fs::canonicalize(&database_dir)
+    //
+    // 2022年12月28日 修正
+    //     Windows環境でも動作するよう、std::fs::canonicalizeを、dunce::canonicalizeに変更
+    //
+    //     stdのcanonicalizeは、Windows環境ではUNCパス（例：\\?\C:\Users\..）を返すが、
+    //     それを元にURLを作成するとSQLiteが受け付けないものになってしまう。dunceの
+    //     canonicalizeは普通のパス（例：C:\Users\）を返すので、それを使えばWindowsでも動く。
+    //
+    //     詳細: https://github.com/tatsuya6502/gihyo-tauri-kanban/pull/1
+    let database_dir_str = dunce::canonicalize(&database_dir)
         .unwrap()
         .to_string_lossy()
         .replace('\\', "/");


### PR DESCRIPTION
このPRは、SQLiteにデータを保存するサンプルプログラム（`kanban-03`）がWindows上では動作しない問題を解決します。

2022年12月中旬に、[Tauriの記事](https://gihyo.jp/article/2022/10/rust-monthly-topics-02)の読者の方から、この問題と解決方法について連絡がありました。ご提案いただいた解決方法のとおり、`dunce`クレートを使う形に修正します。

## 変更内容

[dunce](https://crates.io/crates/dunce)クレートを導入し、main.rsの[135行目](https://github.com/tatsuya6502/gihyo-tauri-kanban/blob/74660f9aa4bad200e0b3a7fd4a6b3c4f89b9fc35/kanban-03/src-tauri/src/main.rs#L135)の以下の行を

```rust
let database_dir_str = std::fs::canonicalize(&database_dir)
```

以下のように変更します。

```rust
let database_dir_str = dunce::canonicalize(&database_dir)
```

## 問題の詳細

[dunceのドキュメント](https://docs.rs/dunce/latest/dunce/)によりますと、Windowsのファイルパスには次の2つの形式があります。

- 通常の（またはレガシーな）パス
    - 例：`C:\Users\username\gihyo-kanban-db`
    - 全てのアプリやライブラリがサポートしていると考えてよい
- Windows NT UNCパス
    - 例：`\\?\C:\Users\username\gihyo-kanban-db`
    - ネットワーク接続された他のPC上のファイルなども指定できる
    - 少数のアプリやライブラリしかサポートしていない

Rustの`std::fs::canonicalize`（[doc](https://doc.rust-lang.org/stable/std/fs/fn.canonicalize.html)）はWindows環境ではUNCパスを返します。`kanban-03`サンプルはそれを以下のようなデータベースURLに変換するため、SQLiteが受け付けない不正なURLになってしまいます。

- `sqlite:////?/C:/Users/username/gihyo-kanban-db/db.sqlite`

`dunce::canonicalize`関数は内部で`std::fs::canonicalize`を呼び、（Windows環境では）返されたUNCパスを通常の／レガシーなパスに変換します。これにより、以下のようなSQLiteが受け付けるデータベースURLを作成できます。

- `sqlite://C:/Users/username/gihyo-kanban-db/db.sqlite`

なお、`dunce::canonicalize`関数は（コンパイルターゲットが）Windows以外の環境のときは、`std::fs::canonicalize`関数が返したパスをそのまま返します。

## 補足情報：SQLiteのUNCパスの対応状況

余談ですが、SQLiteのデータベースURLのパーサは、その仕様により、UNCパスをそのまま渡すと正しくパースできないそうです。以下のチケットに、その理由と回避方法が書かれています。

- [System.Data.SQLite: unable to open database file on a local network #bbdda6eae2](https://system.data.sqlite.org/index.html/info/bbdda6eae2)